### PR TITLE
feat: add help overlay with keyboard shortcut reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ from qr_provider import QrImageProvider
 from remote_server import RemoteServer
 from slideshow_controller import SlideshowController
 
-APP_VERSION = "0.1 alpha"
+APP_VERSION = "0.2 beta"
 
 _FROZEN = getattr(sys, "frozen", False)
 

--- a/qml/AdvancedSettingsDialog.qml
+++ b/qml/AdvancedSettingsDialog.qml
@@ -26,6 +26,9 @@ Popup {
     focus: true
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
+    onOpened: { var w = parent ? parent.Window.window : null; if (w) w.advancedOpen = true  }
+    onClosed:  { var w = parent ? parent.Window.window : null; if (w) w.advancedOpen = false }
+
     background: Rectangle {
         radius: 20
         color: Theme.bgCard
@@ -33,9 +36,7 @@ Popup {
         border.width: 1
     }
 
-    Overlay.modal: Rectangle {
-        color: Qt.rgba(0, 0, 0, 0.5)
-    }
+    Overlay.modal: Rectangle { color: Qt.rgba(0, 0, 0, 0.5) }
 
     contentItem: ColumnLayout {
         spacing: 0

--- a/qml/HelpOverlay.qml
+++ b/qml/HelpOverlay.qml
@@ -1,0 +1,279 @@
+// This file is part of picture-show3.
+// Copyright (C) 2026  Sebastian Schäfer
+//
+// picture-show3 is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// picture-show3 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with picture-show3.  If not, see <https://www.gnu.org/licenses/>.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "."
+
+Popup {
+    id: root
+    anchors.centerIn: Overlay.overlay
+    width: Math.min(parent.width - 64, 660)
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    leftPadding: 28; rightPadding: 28; topPadding: 24; bottomPadding: 24
+
+    background: Rectangle {
+        radius: 20
+        color: Theme.bgCard
+        border.color: Theme.surface
+        border.width: 1
+    }
+
+    Overlay.modal: Rectangle { color: Qt.rgba(0, 0, 0, 0.6) }
+
+    property int revealStep: -1
+
+    onOpened: {
+        keyFocus.forceActiveFocus()
+        revealStep = -1
+        revealTimer.start()
+    }
+    onClosed: {
+        revealTimer.stop()
+        revealStep = -1
+    }
+
+    Timer {
+        id: revealTimer
+        interval: 35
+        repeat: true
+        onTriggered: {
+            root.revealStep++
+            if (root.revealStep >= 11) stop()
+        }
+    }
+
+    contentItem: Item {
+        id: keyFocus
+        focus: true
+        implicitHeight: contentCol.implicitHeight
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Question) {
+                root.close()
+                event.accepted = true
+            } else if (event.key === Qt.Key_F) {
+                var win = Window.window
+                if (win.visibility === Window.FullScreen)
+                    win.showNormal()
+                else {
+                    windowHelper.saveWindowed()
+                    win.showFullScreen()
+                }
+                event.accepted = true
+            }
+        }
+
+        ColumnLayout {
+            id: contentCol
+            width: parent.width
+            spacing: 18
+
+            // ── Title + version ───────────────────────────────────────────────
+            Row {
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 10
+                Image {
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: "../img/logo.svg"
+                    fillMode: Image.PreserveAspectFit
+                    width: 180; height: 28
+                    smooth: true; mipmap: true
+                    sourceSize.width: 360
+                }
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "—  HELP"
+                    color: Theme.accentLight
+                    font.pixelSize: 18
+                    font.weight: Font.Bold
+                }
+            }
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: "v" + appVersion
+                color: Theme.textSubtle
+                font.pixelSize: 12
+                topPadding: -10
+            }
+
+            // ── Description ───────────────────────────────────────────────────
+            Text {
+                Layout.fillWidth: true
+                text: "A full-screen photo slideshow viewer. Browse to a folder, configure transitions and sort order, then press ↵ to start. Control the show from the keyboard or from a smartphone via the built-in remote."
+                color: Theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.Wrap
+                lineHeight: 1.4
+            }
+
+            // ── License ───────────────────────────────────────────────────────
+            Text {
+                Layout.fillWidth: true
+                text: "© 2026 Sebastian Schäfer  ·  Released under the GNU General Public License v3"
+                color: Theme.textMuted
+                font.pixelSize: 11
+                wrapMode: Text.Wrap
+            }
+
+            // ── Divider ───────────────────────────────────────────────────────
+            Rectangle { Layout.fillWidth: true; height: 1; color: Theme.surface }
+
+            // ── Keyboard shortcuts ────────────────────────────────────────────
+            // Each row: fixed-width key cell so descriptions align as a column.
+            //   settings key cell: 44 px (fits "Esc")
+            //   in-show  key cell: 58 px (fits "← →" and "Space")
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 20
+
+                // Settings page column
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignTop
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    Text {
+                        text: "SETTINGS PAGE"
+                        color: Theme.textMuted
+                        font.pixelSize: 10
+                        font.weight: Font.Medium
+                        font.letterSpacing: 1.4
+                        bottomPadding: 2
+                    }
+
+                    Repeater {
+                        model: [
+                            { keys: ["T"],   desc: "Cycle transition"   },
+                            { keys: ["S"],   desc: "Cycle sort order"   },
+                            { keys: ["L"],   desc: "Toggle loop"        },
+                            { keys: ["A"],   desc: "Toggle autoplay"    },
+                            { keys: ["B"],   desc: "Browse folder"      },
+                            { keys: ["R"],   desc: "Star rating filter" },
+                            { keys: ["↵"],   desc: "Start / resume show"},
+                            { keys: ["V"],   desc: "Advanced settings"  },
+                            { keys: ["F"],   desc: "Toggle fullscreen"  },
+                            { keys: ["Esc"], desc: "Quit dialog"        },
+                            { keys: ["?"],   desc: "Help"               }
+                        ]
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            opacity: index <= root.revealStep ? 1 : 0
+                            scale: index <= root.revealStep ? 1.0 : 0.85
+                            transformOrigin: Item.Left
+                            Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                            Behavior on scale { NumberAnimation { duration: 300; easing.type: Easing.OutBack } }
+                            Item {
+                                implicitWidth: 44
+                                implicitHeight: keyRow.implicitHeight
+                                Row {
+                                    id: keyRow
+                                    anchors.left: parent.left
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 4
+                                    Repeater {
+                                        model: modelData.keys
+                                        KeyHint { label: modelData }
+                                    }
+                                }
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.desc
+                                color: Theme.textSecondary
+                                font.pixelSize: 12
+                            }
+                        }
+                    }
+                }
+
+                // In-show column
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignTop
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    Text {
+                        text: "IN SHOW"
+                        color: Theme.textMuted
+                        font.pixelSize: 10
+                        font.weight: Font.Medium
+                        font.letterSpacing: 1.4
+                        bottomPadding: 2
+                    }
+
+                    Repeater {
+                        model: [
+                            { keys: ["←","→"], desc: "Navigate"         },
+                            { keys: ["Space"],  desc: "Play / pause"     },
+                            { keys: ["F"],      desc: "Toggle fullscreen"},
+                            { keys: ["I"],      desc: "Toggle info HUD"  },
+                            { keys: ["Esc"],    desc: "Exit show"        },
+                            { keys: ["?"],      desc: "Help"             }
+                        ]
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            opacity: index <= root.revealStep ? 1 : 0
+                            scale: index <= root.revealStep ? 1.0 : 0.85
+                            transformOrigin: Item.Left
+                            Behavior on opacity { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                            Behavior on scale { NumberAnimation { duration: 300; easing.type: Easing.OutBack } }
+                            Item {
+                                implicitWidth: 58
+                                implicitHeight: keyRow2.implicitHeight
+                                Row {
+                                    id: keyRow2
+                                    anchors.left: parent.left
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 4
+                                    Repeater {
+                                        model: modelData.keys
+                                        KeyHint { label: modelData }
+                                    }
+                                }
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.desc
+                                color: Theme.textSecondary
+                                font.pixelSize: 12
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Divider ───────────────────────────────────────────────────────
+            Rectangle { Layout.fillWidth: true; height: 1; color: Theme.surface }
+
+            // ── Close hint ────────────────────────────────────────────────────
+            Row {
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 6
+                Text { anchors.verticalCenter: parent.verticalCenter; text: "Press"; color: Theme.textGhost; font.pixelSize: 11 }
+                KeyHint { anchors.verticalCenter: parent.verticalCenter; label: "?" }
+                Text { anchors.verticalCenter: parent.verticalCenter; text: "or"; color: Theme.textGhost; font.pixelSize: 11 }
+                KeyHint { anchors.verticalCenter: parent.verticalCenter; label: "Esc" }
+                Text { anchors.verticalCenter: parent.verticalCenter; text: "to close"; color: Theme.textGhost; font.pixelSize: 11 }
+            }
+        }
+    }
+}

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -41,6 +41,7 @@ Item {
     }
 
     signal startShow()
+    signal openHelp()
 
     function launchShow() {
         if (controller.imageCount === 0) return
@@ -102,6 +103,12 @@ Item {
         case Qt.Key_H:
             if (controller.folderHistory.length > 0)
                 recentPopup.open()
+            break
+        case Qt.Key_V:
+            advancedDialog.open()
+            break
+        case Qt.Key_Question:
+            root.openHelp()
             break
         default:
             break
@@ -1185,24 +1192,56 @@ Item {
                     // ── Divider ───────────────────────────────────────────────
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.surface }
 
-                    // ── Advanced settings link ────────────────────────────────
+                    // ── Advanced settings link + Help link ────────────────────
                     RowLayout {
                         Layout.fillWidth: true
+
+                        Rectangle {
+                            height: 32; radius: 8
+                            width: helpRow.implicitWidth + 24
+                            color: helpArea.containsMouse ? Theme.surfaceHover : "transparent"
+                            Behavior on color { ColorAnimation { duration: 120 } }
+
+                            Row {
+                                id: helpRow
+                                anchors.centerIn: parent
+                                spacing: 6
+                                Text {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    text: "Help"
+                                    color: Theme.textMuted
+                                    font.pixelSize: 12
+                                }
+                                KeyHint { anchors.verticalCenter: parent.verticalCenter; label: "?" }
+                            }
+                            MouseArea {
+                                id: helpArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.openHelp()
+                            }
+                        }
 
                         Item { Layout.fillWidth: true }
 
                         Rectangle {
                             height: 32; radius: 8
-                            width: advancedLabel.implicitWidth + 24
+                            width: advancedRow.implicitWidth + 24
                             color: advancedArea.containsMouse ? Theme.surfaceHover : "transparent"
                             Behavior on color { ColorAnimation { duration: 120 } }
 
-                            Text {
-                                id: advancedLabel
+                            Row {
+                                id: advancedRow
                                 anchors.centerIn: parent
-                                text: "Advanced settings ›"
-                                color: Theme.textMuted
-                                font.pixelSize: 12
+                                spacing: 6
+                                Text {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    text: "Advanced settings ›"
+                                    color: Theme.textMuted
+                                    font.pixelSize: 12
+                                }
+                                KeyHint { anchors.verticalCenter: parent.verticalCenter; label: "V" }
                             }
                             MouseArea {
                                 id: advancedArea

--- a/qml/SlideshowPage.qml
+++ b/qml/SlideshowPage.qml
@@ -25,6 +25,7 @@ Rectangle {
     clip: true   // keep sliding layers from painting outside the window
 
     signal exitShow()
+    signal openHelp()
 
     // ── State ─────────────────────────────────────────────────────────────────
     property bool showingA  : true   // which layer is currently the foreground
@@ -222,6 +223,9 @@ Rectangle {
         case Qt.Key_I:
             root.hudVisible = !root.hudVisible
             controller.setHudVisible(root.hudVisible)
+            break
+        case Qt.Key_Question:
+            root.openHelp()
             break
         default:
             break

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -15,6 +15,7 @@
 // along with picture-show3.  If not, see <https://www.gnu.org/licenses/>.
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Effects
 import "."
 
 ApplicationWindow {
@@ -27,10 +28,21 @@ ApplicationWindow {
     title: "picture show 3"
     color: Theme.bgDeep
 
+    // Set to true by AdvancedSettingsDialog (via SettingsPage) to blur the stack
+    property bool advancedOpen: false
+
     // ── Page stack ────────────────────────────────────────────────────────────
     StackView {
         id: stack
         anchors.fill: parent
+
+        // Blur the stack behind any modal dialog — uses scene-graph layer, survives fullscreen
+        layer.enabled: root.advancedOpen || helpOverlay.visible
+        layer.effect: MultiEffect {
+            blurEnabled: true
+            blur: 0.8
+            blurMax: 48
+        }
 
         // Push is instant — SettingsPage.launchAnim handles the visual transition
         pushEnter: Transition { }
@@ -62,6 +74,12 @@ ApplicationWindow {
         }
     }
 
+    // ── Help overlay (above all pages) ───────────────────────────────────────
+    HelpOverlay {
+        id: helpOverlay
+        onClosed: stack.currentItem.forceActiveFocus()
+    }
+
     // ── Pages ─────────────────────────────────────────────────────────────────
     Component {
         id: settingsComp
@@ -76,6 +94,7 @@ ApplicationWindow {
                 remoteServer.setShowActive(true)
                 stack.push(slideshowComp)
             }
+            onOpenHelp: helpOverlay.open()
         }
     }
 
@@ -93,6 +112,7 @@ ApplicationWindow {
                 stack.pop()
                 sp.triggerSlideIn()
             }
+            onOpenHelp: helpOverlay.open()
         }
     }
 }

--- a/resources.qrc
+++ b/resources.qrc
@@ -7,6 +7,7 @@
     <file>qml/AdvancedSettingsDialog.qml</file>
     <file>qml/QrCodeDialog.qml</file>
     <file>qml/KeyHint.qml</file>
+    <file>qml/HelpOverlay.qml</file>
     <file>qml/ThemedIcon.qml</file>
     <file>qml/Theme.qml</file>
     <file>qml/qmldir</file>


### PR DESCRIPTION
Add HelpOverlay.qml with two-column keyboard shortcut listing for settings page and in-show controls, accessible via ? key from both pages. Includes staggered key-row reveal animation, blur backdrop on the StackView, and Help/Advanced Settings links with KeyHint badges. Bump version to 0.2 beta.