### PR TITLE
feat: allow deleting individual entries from the recent folders history

### DIFF
--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -524,6 +524,14 @@ Item {
                                     event.accepted = true
                                     break
                                 }
+                                case Qt.Key_Delete: {
+                                    var delPath = controller.folderHistory[recentPopup.selectedIndex]
+                                    if (recentPopup.selectedIndex >= controller.folderHistory.length - 1)
+                                        recentPopup.selectedIndex = Math.max(0, recentPopup.selectedIndex - 1)
+                                    controller.removeFolderHistory(delPath)
+                                    event.accepted = true
+                                    break
+                                }
                                 default:
                                     break
                                 }
@@ -583,25 +591,63 @@ Item {
                                             model: controller.folderHistory
 
                                             delegate: Rectangle {
+                                                id: recentDelegate
                                                 width: recentListCol.width - 10
                                                 height: 40
                                                 radius: 10
                                                 color: (recentPopup.selectedIndex === index)
                                                        ? Theme.accentDeep
-                                                       : (recentItemArea.containsMouse ? Theme.surface : "transparent")
+                                                       : (rowHover.hovered ? Theme.surface : "transparent")
                                                 Behavior on color { ColorAnimation { duration: 100 } }
                                                 border.color: recentPopup.selectedIndex === index ? Theme.accent : "transparent"
                                                 border.width: 1
 
+                                                // Tracks hover over the entire row (including over child MouseAreas)
+                                                HoverHandler { id: rowHover }
+
                                                 Text {
-                                                    anchors { left: parent.left; right: parent.right
+                                                    anchors { left: parent.left; right: deleteBtn.left
                                                               verticalCenter: parent.verticalCenter
-                                                              leftMargin: 12; rightMargin: 12 }
+                                                              leftMargin: 12; rightMargin: 4 }
                                                     text: modelData
-                                                    color: recentPopup.selectedIndex === index ? Theme.textPrimary : Theme.textPrimary
+                                                    color: Theme.textPrimary
                                                     font.pixelSize: 13
                                                     elide: Text.ElideLeft
                                                 }
+
+                                                // Delete button — visible on row hover
+                                                Rectangle {
+                                                    id: deleteBtn
+                                                    anchors { right: parent.right; rightMargin: 6
+                                                              verticalCenter: parent.verticalCenter }
+                                                    width: 28; height: 28
+                                                    radius: 6
+                                                    z: 1
+                                                    color: deleteArea.containsMouse ? Theme.accentPress : "transparent"
+                                                    Behavior on color { ColorAnimation { duration: 80 } }
+                                                    visible: rowHover.hovered
+
+                                                    Text {
+                                                        anchors.centerIn: parent
+                                                        text: "×"
+                                                        color: deleteArea.containsMouse ? "white" : Theme.textMuted
+                                                        font.pixelSize: 16
+                                                    }
+                                                    MouseArea {
+                                                        id: deleteArea
+                                                        anchors.fill: parent
+                                                        hoverEnabled: true
+                                                        cursorShape: Qt.PointingHandCursor
+                                                        onClicked: {
+                                                            var path = modelData
+                                                            // Clamp selected index so it doesn't go out of bounds
+                                                            if (recentPopup.selectedIndex >= controller.folderHistory.length - 1)
+                                                                recentPopup.selectedIndex = Math.max(0, recentPopup.selectedIndex - 1)
+                                                            controller.removeFolderHistory(path)
+                                                        }
+                                                    }
+                                                }
+
                                                 MouseArea {
                                                     id: recentItemArea
                                                     anchors.fill: parent

--- a/slideshow_controller.py
+++ b/slideshow_controller.py
@@ -301,6 +301,13 @@ class SlideshowController(QObject):
         self._save_settings()
         self.folderHistoryChanged.emit()
 
+    @Slot(str)
+    def removeFolderHistory(self, path: str) -> None:
+        if path in self._folder_history:
+            self._folder_history.remove(path)
+            self._save_settings()
+            self.folderHistoryChanged.emit()
+
     def _cancel_and_new_event(self) -> threading.Event:
         """Signal the running worker to stop and return a fresh cancel event."""
         self._cancel_event.set()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -287,6 +287,23 @@ class TestFolderHistory:
         h.append("/intruder")
         assert "/intruder" not in ctrl.folderHistory
 
+    def test_remove_existing_entry(self, ctrl):
+        ctrl._update_history("/fake/alpha")
+        ctrl._update_history("/fake/beta")
+        ctrl.removeFolderHistory("/fake/alpha")
+        assert "/fake/alpha" not in ctrl.folderHistory
+        assert "/fake/beta" in ctrl.folderHistory
+
+    def test_remove_nonexistent_entry_is_noop(self, ctrl):
+        ctrl._update_history("/fake/alpha")
+        ctrl.removeFolderHistory("/fake/does-not-exist")
+        assert ctrl.folderHistory == ["/fake/alpha"]
+
+    def test_remove_only_entry_leaves_empty(self, ctrl):
+        ctrl._update_history("/fake/alpha")
+        ctrl.removeFolderHistory("/fake/alpha")
+        assert ctrl.folderHistory == []
+
 
 # ── Playback state machine ────────────────────────────────────────────────────
 
@@ -524,6 +541,16 @@ class TestSignals:
         ctrl._update_history("/fake/x")
         with qtbot.waitSignal(ctrl.folderHistoryChanged, timeout=1000):
             ctrl.clearFolderHistory()
+
+    def test_folder_history_changed_on_remove(self, ctrl, qtbot):
+        ctrl._update_history("/fake/x")
+        with qtbot.waitSignal(ctrl.folderHistoryChanged, timeout=1000):
+            ctrl.removeFolderHistory("/fake/x")
+
+    def test_folder_history_no_signal_on_remove_missing(self, ctrl, qtbot):
+        ctrl._update_history("/fake/x")
+        with qtbot.assertNotEmitted(ctrl.folderHistoryChanged):
+            ctrl.removeFolderHistory("/fake/does-not-exist")
 
 
 # ── Recursive search ──────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add removeFolderHistory(path) slot in SlideshowController
- History popup: × delete button visible on row hover (HoverHandler fix)
- History popup: DEL key removes the currently selected entry
- 5 new tests for removeFolderHistory (logic + signal behaviour)