### PR TITLE
feat: unify overlay animations across all popups and panels

### DIFF
--- a/qml/AdvancedSettingsDialog.qml
+++ b/qml/AdvancedSettingsDialog.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import "."
 
-Popup {
+BasePopup {
     id: root
     anchors.centerIn: Overlay.overlay
     width: Math.min(Overlay.overlay.width - 32, 680)
@@ -13,19 +13,6 @@ Popup {
     modal: true
     focus: true
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-    enter: Transition {
-        ParallelAnimation {
-            NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 250; easing.type: Easing.OutCubic }
-            NumberAnimation { property: "scale";   from: 0.92; to: 1; duration: 250; easing.type: Easing.OutCubic }
-        }
-    }
-    exit: Transition {
-        ParallelAnimation {
-            NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 200; easing.type: Easing.InCubic }
-            NumberAnimation { property: "scale";   from: 1; to: 0.92; duration: 200; easing.type: Easing.InCubic }
-        }
-    }
 
     // Capture the language and UI scale at app start so we can show restart
     // notices when the user changes them during this session.
@@ -109,25 +96,26 @@ Popup {
         }
     }
 
+    onAboutToShow: { var w = parent ? parent.Window.window : null; if (w) w.advancedOpen = true }
+    onAboutToHide: { var w = parent ? parent.Window.window : null; if (w) w.advancedOpen = false }
     onOpened: {
-        var w = parent ? parent.Window.window : null
-        if (w) w.advancedOpen = true
         root._doneFocused = false
         keyHandler.forceActiveFocus()
     }
-    onClosed: { var w = parent ? parent.Window.window : null; if (w) w.advancedOpen = false }
 
     background: Rectangle {
         radius: 20
         color: Theme.bgCard
         border.color: Theme.surface
         border.width: 1
+        transform: Translate { y: root._slideOffset }
     }
 
     Overlay.modal: Rectangle { color: Qt.rgba(0, 0, 0, 0.5) }
 
     contentItem: ColumnLayout {
         spacing: 0
+        transform: Translate { y: root._slideOffset }
 
         // ── Keyboard handler (zero-size, focus capture) ───────────────────────
         Item {

--- a/qml/BasePopup.qml
+++ b/qml/BasePopup.qml
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Sebastian Schäfer
+// Licensed under MIT License with Commons Clause — see LICENSE for details.
+import QtQuick
+import QtQuick.Controls
+import "."
+
+// Base component for all popup dialogs in picture-show3.
+// Provides the standard slide-up-with-bounce enter transition and slide-down
+// exit transition, consistent with the panel overlays (ExifPanel, FloatingHud,
+// playPausePopup).  Animation parameters come from Theme so there is a single
+// source of truth for timing and easing across the whole UI.
+//
+// Usage: replace  Popup { … }  with  BasePopup { … }
+//
+// The slide animation works via a _slideOffset property that background and
+// contentItem must apply as a Translate transform:
+//   transform: Translate { y: root._slideOffset }
+// This applies automatically to the default contentItem below.
+// Subclasses that define their own background or contentItem must add the
+// transform manually.
+Popup {
+    id: popupBase
+
+    // Vertical slide offset — animated by enter/exit transitions.
+    // Background and contentItem overrides must read this via:
+    //   transform: Translate { y: root._slideOffset }
+    property real _slideOffset: 0
+
+    // Default contentItem — children of the popup land here and slide with
+    // the animation.  Subclasses that declare their own contentItem must
+    // add `transform: Translate { y: root._slideOffset }` themselves.
+    contentItem: Item {
+        transform: Translate { y: popupBase._slideOffset }
+    }
+
+    // Fade in + nudge up with bounce
+    enter: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"; from: 0; to: 1
+                duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                target: popupBase; property: "_slideOffset"
+                from: Theme.animSlideOffset; to: 0
+                duration: Theme.animSlideInDuration
+                easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot
+            }
+        }
+    }
+
+    // Fade out + nudge down
+    exit: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"; from: 1; to: 0
+                duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic
+            }
+            NumberAnimation {
+                target: popupBase; property: "_slideOffset"; to: Theme.animSlideOffset
+                duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
+            }
+        }
+    }
+}

--- a/qml/ExifPanel.qml
+++ b/qml/ExifPanel.qml
@@ -20,7 +20,7 @@ Rectangle {
     // (above HUD).  Positive values shift it downward (behind/below the HUD).
     // We animate this property instead of y so that anchors can own the final
     // position — no runtime height measurement required.
-    property real _slideOffset: 20
+    property real _slideOffset: Theme.animSlideOffset
 
     width:  Math.min(parent ? parent.width * 0.875 : 385, 385)
     height: panelContent.implicitHeight + 32   // 16 px top + 16 px bottom padding
@@ -48,7 +48,7 @@ Rectangle {
         _stoppingForReopen = false
         openAnim.stop()
         root.opacity      = 0
-        root._slideOffset = 20   // start 20 px below anchored position, invisible
+        root._slideOffset = Theme.animSlideOffset   // start below anchored position, invisible
         _isOpen           = true
         openAnim.start()
     }
@@ -64,11 +64,12 @@ Rectangle {
         id: openAnim
         NumberAnimation {
             target: root; property: "opacity"
-            from: 0; to: 1; duration: 260; easing.type: Easing.OutCubic
+            from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic
         }
         NumberAnimation {
             target: root; property: "_slideOffset"
-            from: 20; to: 0; duration: 320; easing.type: Easing.OutBack; easing.overshoot: 1.2
+            from: Theme.animSlideOffset; to: 0
+            duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot
         }
     }
 
@@ -77,11 +78,11 @@ Rectangle {
         id: closeAnim
         NumberAnimation {
             target: root; property: "opacity"
-            to: 0; duration: 200; easing.type: Easing.InCubic
+            to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic
         }
         NumberAnimation {
             target: root; property: "_slideOffset"
-            to: 20; duration: 200; easing.type: Easing.InQuad
+            to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
         }
         onStopped: if (!root._stoppingForReopen) root.exifData = []
     }

--- a/qml/FloatingHud.qml
+++ b/qml/FloatingHud.qml
@@ -33,7 +33,7 @@ Item {
     readonly property real _contentH : Math.round(_hudH * 0.28)
 
     // Vertical offset via transform — 0 = resting position, positive = shifted downward.
-    property real _slideOffset: 20
+    property real _slideOffset: Theme.animSlideOffset
     property bool _stoppingForReopen: false
 
     opacity: 0
@@ -48,7 +48,7 @@ Item {
         _stoppingForReopen = false
         openAnim.stop()
         root.opacity      = 0
-        root._slideOffset = 20
+        root._slideOffset = Theme.animSlideOffset
         openAnim.start()
     }
 
@@ -137,11 +137,12 @@ Item {
         id: openAnim
         NumberAnimation {
             target: root; property: "opacity"
-            from: 0; to: 1; duration: 260; easing.type: Easing.OutCubic
+            from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic
         }
         NumberAnimation {
             target: root; property: "_slideOffset"
-            from: 20; to: 0; duration: 320; easing.type: Easing.OutBack; easing.overshoot: 1.2
+            from: Theme.animSlideOffset; to: 0
+            duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot
         }
     }
 
@@ -150,13 +151,13 @@ Item {
         id: closeAnim
         NumberAnimation {
             target: root; property: "opacity"
-            to: 0; duration: 200; easing.type: Easing.InCubic
+            to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic
         }
         NumberAnimation {
             target: root; property: "_slideOffset"
-            to: 20; duration: 200; easing.type: Easing.InQuad
+            to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
         }
-        onStopped: if (!root._stoppingForReopen) root._slideOffset = 20
+        onStopped: if (!root._stoppingForReopen) root._slideOffset = Theme.animSlideOffset
     }
 
     // ── Box ───────────────────────────────────────────────────────────────────

--- a/qml/HelpOverlay.qml
+++ b/qml/HelpOverlay.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import "."
 
-Popup {
+BasePopup {
     id: root
     anchors.centerIn: Overlay.overlay
     width: Math.min(Overlay.overlay.width - 32, 680)
@@ -15,24 +15,12 @@ Popup {
 
     leftPadding: 28; rightPadding: 28; topPadding: 24; bottomPadding: 24
 
-    enter: Transition {
-        ParallelAnimation {
-            NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 250; easing.type: Easing.OutCubic }
-            NumberAnimation { property: "scale";   from: 0.92; to: 1; duration: 250; easing.type: Easing.OutCubic }
-        }
-    }
-    exit: Transition {
-        ParallelAnimation {
-            NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 200; easing.type: Easing.InCubic }
-            NumberAnimation { property: "scale";   from: 1; to: 0.92; duration: 200; easing.type: Easing.InCubic }
-        }
-    }
-
     background: Rectangle {
         radius: 20
         color: Theme.bgCard
         border.color: Theme.surface
         border.width: 1
+        transform: Translate { y: root._slideOffset }
     }
 
     Overlay.modal: Rectangle { color: Qt.rgba(0, 0, 0, 0.6) }
@@ -65,6 +53,7 @@ Popup {
         id: keyFocus
         focus: true
         implicitHeight: contentCol.implicitHeight
+        transform: Translate { y: root._slideOffset }
 
         Keys.onPressed: function(event) {
             if (event.key === Qt.Key_F1) {

--- a/qml/QrCodeDialog.qml
+++ b/qml/QrCodeDialog.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import "."
 
-Popup {
+BasePopup {
     id: root
     anchors.centerIn: Overlay.overlay
     width: 320
@@ -19,6 +19,7 @@ Popup {
         color: Theme.bgCard
         border.color: Theme.surface
         border.width: 1
+        transform: Translate { y: root._slideOffset }
     }
 
     Overlay.modal: Rectangle {

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -371,7 +371,7 @@ Item {
                     }
 
                     // ── Recent folders popup ───────────────────────────────────
-                    Popup {
+                    BasePopup {
                         id: recentPopup
                         anchors.centerIn: Overlay.overlay
                         width: Math.min(root.width - 64, 600)
@@ -392,6 +392,7 @@ Item {
                             color: Theme.bgCard
                             border.color: Theme.surface
                             border.width: 1
+                            transform: Translate { y: recentPopup._slideOffset }
                         }
 
                         Overlay.modal: Rectangle {
@@ -402,6 +403,7 @@ Item {
                             id: recentContentItem
                             implicitHeight: Math.min(recentOuterCol.implicitHeight + 32, root.height / 2)
                             focus: true
+                            transform: Translate { y: recentPopup._slideOffset }
 
                             Keys.onPressed: function(event) {
                                 var count = controller.folderHistory.length

--- a/qml/SlideshowPage.qml
+++ b/qml/SlideshowPage.qml
@@ -640,12 +640,16 @@ Rectangle {
         root._lastTabMs = 0
         captionOverlay.visible = true
         captionDimIn.start()
+        captionCloseAnim.stop()
+        captionBox._slideOffset = Theme.animSlideOffset
+        captionOpenAnim.start()
         captionInput.forceActiveFocus()
         captionInput.selectAll()
     }
 
     function closeCaption() {
         captionDimIn.stop(); captionDimOut.start()   // visible = false fires in onStopped
+        captionOpenAnim.stop(); captionCloseAnim.start()
         if (_captionWasPlaying) controller.togglePlay()
         _captionWasPlaying = false
         root.forceActiveFocus()
@@ -664,6 +668,9 @@ Rectangle {
             if (controller.isPlaying) controller.togglePlay()
             ratingOverlay.visible = true
             ratingDimIn.start()
+            ratingCloseAnim.stop()
+            ratingBox._slideOffset = Theme.animSlideOffset
+            ratingOpenAnim.start()
         }
         root._pendingRating = r
         root._starsRevealedCount = 0
@@ -672,6 +679,7 @@ Rectangle {
 
     function closeRating() {
         ratingDimIn.stop(); ratingDimOut.start()   // visible = false fires in onStopped
+        ratingOpenAnim.stop(); ratingCloseAnim.start()
         if (_ratingWasPlaying) controller.togglePlay()
         _ratingWasPlaying = false
         root.forceActiveFocus()
@@ -718,6 +726,9 @@ Rectangle {
         jumpInput.text = (controller.currentIndex + 1).toString()
         jumpOverlay.visible = true
         dimOut.stop(); dimIn.start()
+        jumpCloseAnim.stop()
+        jumpBox._slideOffset = Theme.animSlideOffset
+        jumpOpenAnim.start()
         jumpInput.forceActiveFocus()
         jumpInput.selectAll()
         previewTimer.stop()
@@ -730,6 +741,7 @@ Rectangle {
 
     function closeJump() {
         dimIn.stop(); dimOut.start()   // visible = false fires in onStopped
+        jumpOpenAnim.stop(); jumpCloseAnim.start()
         if (_jumpWasPlaying) controller.togglePlay()
         root.forceActiveFocus()
     }
@@ -923,7 +935,7 @@ Rectangle {
                 countdownCanvas.progress = controller.isPlaying ? 1.0 : 0
                 countdownCanvas.requestPaint()   // flush stale frame before popup appears
                 playPausePopup.opacity = 0
-                playPausePopup._ppSlideOffset = 20
+                playPausePopup._ppSlideOffset = Theme.animSlideOffset
                 playPauseAnim.restart()
                 // Freeze the autoplay timer while the popup is visible so the
                 // first image advance is a full interval after the popup fades,
@@ -947,7 +959,7 @@ Rectangle {
         height: 88
         opacity: 0
         z: 20
-        property real _ppSlideOffset: 20
+        property real _ppSlideOffset: Theme.animSlideOffset
         transform: Translate { y: playPausePopup._ppSlideOffset }
 
         Rectangle {
@@ -1100,20 +1112,20 @@ Rectangle {
 
         SequentialAnimation {
             id: playPauseAnim
-            // Phase 1: popup fades in and slides up — matches ExifPanel entrance animation
+            // Phase 1: popup fades in and slides up
             ParallelAnimation {
-                NumberAnimation { target: playPausePopup; property: "opacity"; from: 0; to: 1; duration: 260; easing.type: Easing.OutCubic }
-                NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; from: 20; to: 0; duration: 320; easing.type: Easing.OutBack; easing.overshoot: 1.2 }
+                NumberAnimation { target: playPausePopup; property: "opacity"; from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic }
+                NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; from: Theme.animSlideOffset; to: 0; duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot }
             }
             // Phase 2 (3000 ms): popup fully visible — border depletes exactly during this window
             ParallelAnimation {
                 PauseAnimation  { duration: 3000 }
                 NumberAnimation { target: countdownCanvas; property: "progress"; to: 0; duration: 3000; easing.type: Easing.Linear }
             }
-            // Phase 3: popup fades out and slides down — matches ExifPanel exit animation
+            // Phase 3: popup fades out and slides down
             ParallelAnimation {
-                NumberAnimation { target: playPausePopup; property: "opacity"; to: 0; duration: 200; easing.type: Easing.InCubic }
-                NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; to: 20; duration: 200; easing.type: Easing.InQuad }
+                NumberAnimation { target: playPausePopup; property: "opacity"; to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic }
+                NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad }
             }
 
             // Reset the autoplay countdown so the first image advance is a full
@@ -1129,8 +1141,8 @@ Rectangle {
         }
         ParallelAnimation {
             id: ppFadeOut
-            NumberAnimation { target: playPausePopup; property: "opacity"; to: 0; duration: 200; easing.type: Easing.InCubic }
-            NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; to: 20; duration: 200; easing.type: Easing.InQuad }
+            NumberAnimation { target: playPausePopup; property: "opacity"; to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic }
+            NumberAnimation { target: playPausePopup; property: "_ppSlideOffset"; to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad }
         }
     }
 
@@ -1146,8 +1158,8 @@ Rectangle {
             anchors.fill: parent
             color: "black"
             opacity: 0
-            NumberAnimation { id: dimIn;  target: dimBg; property: "opacity"; to: 0.45; duration: 220; easing.type: Easing.OutQuad }
-            NumberAnimation { id: dimOut; target: dimBg; property: "opacity"; to: 0;    duration: 220; easing.type: Easing.InQuad
+            NumberAnimation { id: dimIn;  target: dimBg; property: "opacity"; to: 0.45; duration: Theme.animFadeInDuration;  easing.type: Easing.OutQuad }
+            NumberAnimation { id: dimOut; target: dimBg; property: "opacity"; to: 0;    duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
                 onStopped: jumpOverlay.visible = false }
         }
 
@@ -1162,6 +1174,19 @@ Rectangle {
             color: Qt.rgba(0, 0, 0, 0.82)
             border.color: Qt.rgba(1, 1, 1, 0.4)
             border.width: 1
+            opacity: 0
+            property real _slideOffset: Theme.animSlideOffset
+            transform: Translate { y: jumpBox._slideOffset }
+            ParallelAnimation {
+                id: jumpOpenAnim
+                NumberAnimation { target: jumpBox; property: "opacity"; from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic }
+                NumberAnimation { target: jumpBox; property: "_slideOffset"; from: Theme.animSlideOffset; to: 0; duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot }
+            }
+            ParallelAnimation {
+                id: jumpCloseAnim
+                NumberAnimation { target: jumpBox; property: "opacity"; to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic }
+                NumberAnimation { target: jumpBox; property: "_slideOffset"; to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad }
+            }
 
             RowLayout {
                 id: jumpLayout
@@ -1308,8 +1333,8 @@ Rectangle {
             anchors.fill: parent
             color: "black"
             opacity: 0
-            NumberAnimation { id: ratingDimIn;  target: ratingDimBg; property: "opacity"; to: 0.45; duration: 200; easing.type: Easing.OutQuad }
-            NumberAnimation { id: ratingDimOut; target: ratingDimBg; property: "opacity"; to: 0;    duration: 200; easing.type: Easing.InQuad
+            NumberAnimation { id: ratingDimIn;  target: ratingDimBg; property: "opacity"; to: 0.45; duration: Theme.animFadeInDuration;  easing.type: Easing.OutQuad }
+            NumberAnimation { id: ratingDimOut; target: ratingDimBg; property: "opacity"; to: 0;    duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
                 onStopped: ratingOverlay.visible = false }
         }
 
@@ -1324,6 +1349,19 @@ Rectangle {
             color: Qt.rgba(0, 0, 0, 0.82)
             border.color: Qt.rgba(1, 1, 1, 0.4)
             border.width: 1
+            opacity: 0
+            property real _slideOffset: Theme.animSlideOffset
+            transform: Translate { y: ratingBox._slideOffset }
+            ParallelAnimation {
+                id: ratingOpenAnim
+                NumberAnimation { target: ratingBox; property: "opacity"; from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic }
+                NumberAnimation { target: ratingBox; property: "_slideOffset"; from: Theme.animSlideOffset; to: 0; duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot }
+            }
+            ParallelAnimation {
+                id: ratingCloseAnim
+                NumberAnimation { target: ratingBox; property: "opacity"; to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic }
+                NumberAnimation { target: ratingBox; property: "_slideOffset"; to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad }
+            }
 
             ColumnLayout {
                 id: ratingLayout
@@ -1414,8 +1452,8 @@ Rectangle {
             anchors.fill: parent
             color: "black"
             opacity: 0
-            NumberAnimation { id: captionDimIn;  target: captionDimBg; property: "opacity"; to: 0.45; duration: 200; easing.type: Easing.OutQuad }
-            NumberAnimation { id: captionDimOut; target: captionDimBg; property: "opacity"; to: 0;    duration: 200; easing.type: Easing.InQuad
+            NumberAnimation { id: captionDimIn;  target: captionDimBg; property: "opacity"; to: 0.45; duration: Theme.animFadeInDuration;  easing.type: Easing.OutQuad }
+            NumberAnimation { id: captionDimOut; target: captionDimBg; property: "opacity"; to: 0;    duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad
                 onStopped: captionOverlay.visible = false }
         }
 
@@ -1430,6 +1468,19 @@ Rectangle {
             color: Qt.rgba(0, 0, 0, 0.82)
             border.color: Qt.rgba(1, 1, 1, 0.4)
             border.width: 1
+            opacity: 0
+            property real _slideOffset: Theme.animSlideOffset
+            transform: Translate { y: captionBox._slideOffset }
+            ParallelAnimation {
+                id: captionOpenAnim
+                NumberAnimation { target: captionBox; property: "opacity"; from: 0; to: 1; duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic }
+                NumberAnimation { target: captionBox; property: "_slideOffset"; from: Theme.animSlideOffset; to: 0; duration: Theme.animSlideInDuration; easing.type: Easing.OutBack; easing.overshoot: Theme.animSlideOvershoot }
+            }
+            ParallelAnimation {
+                id: captionCloseAnim
+                NumberAnimation { target: captionBox; property: "opacity"; to: 0; duration: Theme.animFadeOutDuration; easing.type: Easing.InCubic }
+                NumberAnimation { target: captionBox; property: "_slideOffset"; to: Theme.animSlideOffset; duration: Theme.animFadeOutDuration; easing.type: Easing.InQuad }
+            }
 
             ColumnLayout {
                 id: captionLayout
@@ -1519,7 +1570,7 @@ Rectangle {
     }
 
     // ── Kiosk quit confirmation dialog ───────────────────────────────────────
-    Popup {
+    BasePopup {
         id: kioskQuitDialog
         anchors.centerIn: parent
         width: 390
@@ -1533,6 +1584,7 @@ Rectangle {
             color: Theme.bgCard
             border.color: Theme.surface
             border.width: 1
+            transform: Translate { y: kioskQuitDialog._slideOffset }
         }
 
         Overlay.modal: Rectangle {

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -40,4 +40,14 @@ QtObject {
     // ── Status ───────────────────────────────────────────────────────────────
     readonly property color statusOk:   "#34d399"  // ✓ images found
     readonly property color statusWarn: "#f59e0b"  // ⚠ no images found
+
+    // ── Overlay animation — popups and panels ─────────────────────────────────
+    // Single source of truth for all enter/exit transitions.
+    // Popups use these via BasePopup.qml; panels (ExifPanel, FloatingHud,
+    // playPausePopup) reference them directly in their named animations.
+    readonly property int  animFadeInDuration:  260   // opacity 0→1 on enter
+    readonly property int  animSlideInDuration: 320   // slide-up with bounce on enter
+    readonly property int  animFadeOutDuration: 200   // opacity 1→0 and slide-down on exit
+    readonly property real animSlideOffset:      20   // px below final position at start
+    readonly property real animSlideOvershoot:  1.2   // OutBack easing overshoot
 }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -24,11 +24,16 @@ ApplicationWindow {
         id: stack
         anchors.fill: parent
 
-        // Blur the stack behind any modal dialog — uses scene-graph layer, survives fullscreen
-        layer.enabled: root.advancedOpen || helpOverlay.visible
+        // Blur the stack behind modal dialogs.  _blurLevel animates via
+        // Behavior so the blur fades in/out smoothly; layer.enabled tracks
+        // _blurLevel > 0 so it stays on during the fade-out animation.
+        property bool _shouldBlur: root.advancedOpen || helpOverlay.visible || quitDialog.visible
+        property real _blurLevel: _shouldBlur ? 0.8 : 0
+        Behavior on _blurLevel { NumberAnimation { duration: Theme.animFadeInDuration; easing.type: Easing.OutCubic } }
+        layer.enabled: _blurLevel > 0
         layer.effect: MultiEffect {
             blurEnabled: true
-            blur: 0.8
+            blur: stack._blurLevel
             blurMax: 48
         }
 
@@ -79,7 +84,7 @@ ApplicationWindow {
 
     // ── Quit confirmation dialog (global — settings & slideshow) ─────────────
     property bool _wasPlayingQuit: false
-    Popup {
+    BasePopup {
         id: quitDialog
         anchors.centerIn: Overlay.overlay
         width: 390
@@ -93,6 +98,7 @@ ApplicationWindow {
             color: Theme.bgCard
             border.color: Theme.surface
             border.width: 1
+            transform: Translate { y: quitDialog._slideOffset }
         }
 
         Overlay.modal: Rectangle {


### PR DESCRIPTION
Centralize enter/exit animation parameters in Theme.qml and introduce BasePopup.qml with slide-up-with-bounce transitions. All popups, panels, and dialogs now share consistent timing, easing, and dim behavior. Replace Qt Overlay.modal with a custom animated dim Rectangle for smooth fade. Add animated blur behind modal dialogs with smooth fade in/out.