### PR TITLE
feat: extend CLI with sort, scale, transition-dur and auto-panorama o…

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,8 @@
 ## Synopsis
 
 ```
-python main.py [--kiosk] [<picture_dir>]
+python main.py [options] [<picture_dir>]
+python main.py --kiosk [options] <picture_dir>
 ```
 
 ## Arguments
@@ -13,6 +14,24 @@ python main.py [--kiosk] [<picture_dir>]
 | `<picture_dir>` | No | Path to a folder of images to load on startup |
 | `--kiosk` | No | Enable kiosk mode (requires `<picture_dir>`) |
 | `--help`, `-h` | No | Print a usage summary and exit |
+
+## Show options
+
+These flags override the corresponding setting and **persist to the INI file** immediately — backing out to the settings page and restarting the show will use the same values.
+
+| Option | Description |
+|---|---|
+| `--autoplay [N]` | Enable autoplay; optionally set the interval to `N` seconds (1–99). Without `N` the last saved interval is kept. |
+| `--transition T` | Set the transition style: `fade` · `slide` · `zoom` · `fadeblack` |
+| `--transition-dur MS` | Set the transition duration in milliseconds (100–3000) |
+| `--sort S` | Set the sort order: `name` · `date` · `random` |
+| `--scale MODE` | Set the image scale mode: `fit` · `fill` |
+| `--auto-panorama` | Enable automatic panorama sweep for wide images during autoplay |
+| `--no-auto-panorama` | Disable automatic panorama sweep |
+| `--recursive` | Enable recursive subfolder scanning |
+| `--loop` | Enable looping at the end of the show |
+| `--no-loop` | Disable looping |
+| `--fullscreen` | Start in fullscreen regardless of the last saved window state |
 
 ## Modes
 
@@ -30,6 +49,7 @@ Starts with the settings page. The last used folder is restored from history.
 
 ```bash
 python main.py <picture_dir>
+python main.py --autoplay 5 --transition slide --sort date <picture_dir>
 ```
 
 Loads `<picture_dir>` and launches the slideshow immediately — the settings page
@@ -48,6 +68,7 @@ restored when the settings page is displayed.
 
 ```bash
 python main.py --kiosk <picture_dir>
+python main.py --kiosk --recursive --loop --auto-panorama --autoplay 10 <picture_dir>
 ```
 
 Designed for unattended display installations. Loads `<picture_dir>` and launches

--- a/main.py
+++ b/main.py
@@ -210,18 +210,33 @@ _HELP = f"""\
 picture-show3 {APP_VERSION} - full-screen photo slideshow
 
 Usage:
-  python main.py                        Open the settings page (normal mode)
-  python main.py <picture_dir>          Jump-start: launch the show directly
-  python main.py --kiosk <picture_dir>  Kiosk mode: unattended display
+  python main.py [options] [<picture_dir>]
+  python main.py --kiosk [options] <picture_dir>
 
 Arguments:
   <picture_dir>   Path to a folder containing images to display.
                   Supported formats: jpg jpeg png gif bmp webp tiff tif heic avif
 
-Options:
+Mode options:
   --kiosk         Kiosk mode - the settings page is never shown.
                   Esc opens a quit confirmation dialog instead of going to settings.
                   Exits with an error if the folder contains no supported images.
+
+Show options (stored to settings, persist across sessions):
+  --autoplay [N]       Enable autoplay; optionally set the interval to N seconds (1–99).
+                       Without N the last saved interval is kept.
+  --transition T       Set the transition style: fade | slide | zoom | fadeblack
+  --transition-dur MS  Set the transition duration in milliseconds (100–3000).
+  --sort S             Set the sort order: name | date | random
+  --scale MODE         Set the image scale mode: fit | fill
+  --auto-panorama      Enable automatic panorama sweep for wide images during autoplay.
+  --no-auto-panorama   Disable automatic panorama sweep.
+  --recursive          Enable recursive subfolder scanning.
+  --loop               Enable looping at the end of the show.
+  --no-loop            Disable looping.
+  --fullscreen         Start in fullscreen regardless of the last saved window state.
+
+General:
   --help, -h      Show this help message and exit.
 
 Modes:
@@ -240,48 +255,84 @@ Modes:
 Examples:
   python main.py
   python main.py "C:\\Users\\me\\Pictures\\Vacation"
-  python main.py --kiosk /mnt/photos
+  python main.py --autoplay 5 --transition slide --fullscreen /mnt/photos
+  python main.py --sort date --scale fill --transition-dur 400 /mnt/photos
+  python main.py --kiosk --recursive --loop --auto-panorama /mnt/photos
 
 Full CLI reference: docs/cli.md
 """
 
 
-def _parse_args() -> tuple[str | None, str | None, list[str]]:
+def _parse_args() -> tuple[str | None, str | None, bool, dict, list[str]]:
     """
-    Parse optional flags and an optional positional <picture_dir> from sys.argv.
+    Parse CLI arguments.
 
-    Supported flags:
-      --help / -h      Print help and exit.
-      --kiosk <path>   Start in kiosk mode with the given folder (path required).
+    Returns (kiosk_folder, start_folder, force_fullscreen, overrides, qt_argv).
 
-    Positional argument (last non-flag arg after the script name):
-      <path>           Start the show directly with the given folder (normal mode).
-
-    Returns (kiosk_folder, start_folder, cleaned_argv).
-    Exactly one of kiosk_folder / start_folder is non-None when a folder is given.
+    overrides  – dict of settings to write to QSettings before the controller
+                 reads them: keys match QSettings keys ('autoplay', 'interval',
+                 'transition', 'recursive', 'loop').
+    qt_argv    – cleaned sys.argv passed to QGuiApplication (unknown flags
+                 forwarded so Qt's own flag handling still works).
     """
-    if "--help" in sys.argv or "-h" in sys.argv:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="picture-show3", add_help=False)
+    parser.add_argument("folder", nargs="?", default=None, metavar="picture_dir")
+    parser.add_argument("--kiosk",      action="store_true", default=False)
+    parser.add_argument("--help", "-h", action="store_true")
+    parser.add_argument(
+        "--autoplay", nargs="?", const=-1, type=int, metavar="SECONDS",
+        help="Enable autoplay; optionally set interval in seconds (1–99)",
+    )
+    parser.add_argument(
+        "--transition", choices=["fade", "slide", "zoom", "fadeblack"], default=None,
+    )
+    parser.add_argument(
+        "--transition-dur", type=int, metavar="MS", default=None,
+    )
+    parser.add_argument(
+        "--sort", choices=["name", "date", "random"], default=None,
+    )
+    parser.add_argument(
+        "--scale", choices=["fit", "fill"], default=None,
+    )
+    parser.add_argument("--auto-panorama", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--recursive",     action="store_true", default=False)
+    parser.add_argument("--loop",          action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--fullscreen",    action="store_true", default=False)
+
+    args, remaining = parser.parse_known_args(sys.argv[1:])
+
+    if args.help:
         print(_HELP, end="")
         sys.exit(0)
 
-    argv = list(sys.argv)
-    kiosk_folder: str | None = None
+    kiosk_folder: str | None = args.folder if args.kiosk else None
+    start_folder: str | None = args.folder if not args.kiosk else None
 
-    for i, arg in enumerate(argv):
-        if arg == "--kiosk" and i + 1 < len(argv):
-            kiosk_folder = argv[i + 1]
-            del argv[i:i + 2]
-            break
+    overrides: dict = {}
+    if args.autoplay is not None:
+        overrides["autoplay"] = True
+        if args.autoplay > 0:
+            overrides["interval"] = args.autoplay * 1000
+    if args.transition is not None:
+        overrides["transition"] = args.transition
+    if args.transition_dur is not None:
+        overrides["transitionDuration"] = max(100, min(3000, args.transition_dur))
+    if args.sort is not None:
+        overrides["sort"] = args.sort
+    if args.scale is not None:
+        overrides["imageFill"] = (args.scale == "fill")
+    if args.auto_panorama is not None:
+        overrides["autoPanorama"] = args.auto_panorama
+    if args.recursive:
+        overrides["recursive"] = True
+    if args.loop is not None:
+        overrides["loop"] = args.loop
 
-    start_folder: str | None = None
-    if kiosk_folder is None and len(argv) > 1:
-        # Accept the last argument as the picture directory if it doesn't look like a flag.
-        last = argv[-1]
-        if not last.startswith("-") and last != argv[0]:
-            start_folder = last
-            argv = argv[:-1]
-
-    return kiosk_folder, start_folder, argv
+    qt_argv = [sys.argv[0]] + remaining
+    return kiosk_folder, start_folder, args.fullscreen, overrides, qt_argv
 
 
 def main() -> None:
@@ -296,17 +347,28 @@ def main() -> None:
     # Force a non-native style so custom Slider background/handle work on all platforms
     QQuickStyle.setStyle("Basic")
 
-    kiosk_folder, start_folder, argv = _parse_args()
+    kiosk_folder, start_folder, force_fullscreen, overrides, argv = _parse_args()
     if kiosk_folder is not None and not Path(kiosk_folder).is_dir():
         print(f"Error: kiosk folder does not exist: {kiosk_folder}", file=sys.stderr)
         sys.exit(1)
     if start_folder is not None and not Path(start_folder).is_dir():
         print(f"Error: folder does not exist: {start_folder}", file=sys.stderr)
         sys.exit(1)
+
     QImageReader.setAllocationLimit(1024)
     app = QGuiApplication(argv)
     app.setApplicationName("picture-show3")
     app.setOrganizationName("picture-show3")
+
+    # Write CLI overrides to QSettings AFTER app name is set so QSettings() resolves
+    # to the correct INI file. This also means values persist — backing to the settings
+    # page and restarting the show will use the same CLI-specified values.
+    if overrides or force_fullscreen:
+        s = QSettings()
+        for key, value in overrides.items():
+            s.setValue(key, value)
+        if force_fullscreen:
+            s.setValue("window/fullscreen", True)
     app.translator = _install_translator(app)   # None if no matching .qm found
     if _FROZEN:
         app.setWindowIcon(QIcon(":/img/icon.svg"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 Sebastian Schäfer
+# Licensed under MIT License with Commons Clause — see LICENSE for details.
+"""
+Tests for main._parse_args() — CLI argument parsing.
+
+All tests monkeypatch sys.argv and call _parse_args() directly.
+No Qt application or display is required.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from main import _parse_args
+
+
+def parse(args: list[str]):
+    """Run _parse_args with the given argument list (sys.argv[1:] equivalent)."""
+    sys.argv = ["picture-show3"] + args
+    return _parse_args()
+
+
+# ── Positional folder / mode detection ───────────────────────────────────────
+
+class TestModeDetection:
+    def test_no_args_all_none(self):
+        kiosk, start, fs, ov, _ = parse([])
+        assert kiosk is None
+        assert start is None
+        assert fs is False
+        assert ov == {}
+
+    def test_positional_folder_is_jump_start(self):
+        kiosk, start, _, _, _ = parse(["/some/folder"])
+        assert kiosk is None
+        assert start == "/some/folder"
+
+    def test_kiosk_flag_assigns_kiosk_folder(self):
+        kiosk, start, _, _, _ = parse(["--kiosk", "/some/folder"])
+        assert kiosk == "/some/folder"
+        assert start is None
+
+    def test_kiosk_without_folder_gives_none(self):
+        kiosk, start, _, _, _ = parse(["--kiosk"])
+        assert kiosk is None
+        assert start is None
+
+    def test_fullscreen_sets_force_flag(self):
+        _, _, fs, _, _ = parse(["--fullscreen"])
+        assert fs is True
+
+    def test_fullscreen_not_in_overrides(self):
+        # --fullscreen is handled separately, not via the overrides dict
+        _, _, _, ov, _ = parse(["--fullscreen"])
+        assert "window/fullscreen" not in ov
+
+
+# ── Unknown flags forwarded to Qt ─────────────────────────────────────────────
+
+class TestQtArgvForwarding:
+    def test_unknown_flag_forwarded(self):
+        # parse_known_args cannot know --platform takes a value, so use = form
+        # so both the flag and its value stay together as one unknown token.
+        _, _, _, _, qt_argv = parse(["--platform=offscreen"])
+        assert "--platform=offscreen" in qt_argv
+
+    def test_known_flags_not_forwarded(self):
+        _, _, _, _, qt_argv = parse(["--recursive", "--loop", "/folder"])
+        # Only sys.argv[0] should be in qt_argv (no known flags, folder is positional)
+        assert "--recursive" not in qt_argv
+        assert "--loop" not in qt_argv
+
+
+# ── Autoplay ──────────────────────────────────────────────────────────────────
+
+class TestAutoplay:
+    def test_autoplay_without_n_enables_but_keeps_interval(self):
+        _, _, _, ov, _ = parse(["--autoplay"])
+        assert ov["autoplay"] is True
+        assert "interval" not in ov
+
+    def test_autoplay_with_n_sets_interval_ms(self):
+        _, _, _, ov, _ = parse(["--autoplay", "5"])
+        assert ov["autoplay"] is True
+        assert ov["interval"] == 5000
+
+    def test_autoplay_with_n_1(self):
+        _, _, _, ov, _ = parse(["--autoplay", "1"])
+        assert ov["interval"] == 1000
+
+    def test_autoplay_with_n_99(self):
+        _, _, _, ov, _ = parse(["--autoplay", "99"])
+        assert ov["interval"] == 99000
+
+    def test_no_autoplay_flag_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "autoplay" not in ov
+
+
+# ── Transition ────────────────────────────────────────────────────────────────
+
+class TestTransition:
+    @pytest.mark.parametrize("style", ["fade", "slide", "zoom", "fadeblack"])
+    def test_valid_transition_style(self, style):
+        _, _, _, ov, _ = parse(["--transition", style])
+        assert ov["transition"] == style
+
+    def test_invalid_transition_exits(self):
+        with pytest.raises(SystemExit):
+            parse(["--transition", "wipe"])
+
+    def test_no_transition_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "transition" not in ov
+
+
+# ── Transition duration ───────────────────────────────────────────────────────
+
+class TestTransitionDuration:
+    def test_transition_dur_stored_as_ms(self):
+        _, _, _, ov, _ = parse(["--transition-dur", "800"])
+        assert ov["transitionDuration"] == 800
+
+    def test_transition_dur_clamped_to_min(self):
+        _, _, _, ov, _ = parse(["--transition-dur", "50"])
+        assert ov["transitionDuration"] == 100
+
+    def test_transition_dur_clamped_to_max(self):
+        _, _, _, ov, _ = parse(["--transition-dur", "9999"])
+        assert ov["transitionDuration"] == 3000
+
+    def test_transition_dur_boundary_100(self):
+        _, _, _, ov, _ = parse(["--transition-dur", "100"])
+        assert ov["transitionDuration"] == 100
+
+    def test_transition_dur_boundary_3000(self):
+        _, _, _, ov, _ = parse(["--transition-dur", "3000"])
+        assert ov["transitionDuration"] == 3000
+
+    def test_no_transition_dur_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "transitionDuration" not in ov
+
+
+# ── Sort ──────────────────────────────────────────────────────────────────────
+
+class TestSort:
+    @pytest.mark.parametrize("order", ["name", "date", "random"])
+    def test_valid_sort_orders(self, order):
+        _, _, _, ov, _ = parse(["--sort", order])
+        assert ov["sort"] == order
+
+    def test_invalid_sort_exits(self):
+        with pytest.raises(SystemExit):
+            parse(["--sort", "size"])
+
+    def test_no_sort_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "sort" not in ov
+
+
+# ── Image scale ───────────────────────────────────────────────────────────────
+
+class TestScale:
+    def test_scale_fit_sets_image_fill_false(self):
+        _, _, _, ov, _ = parse(["--scale", "fit"])
+        assert ov["imageFill"] is False
+
+    def test_scale_fill_sets_image_fill_true(self):
+        _, _, _, ov, _ = parse(["--scale", "fill"])
+        assert ov["imageFill"] is True
+
+    def test_invalid_scale_exits(self):
+        with pytest.raises(SystemExit):
+            parse(["--scale", "stretch"])
+
+    def test_no_scale_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "imageFill" not in ov
+
+
+# ── Auto panorama ─────────────────────────────────────────────────────────────
+
+class TestAutoPanorama:
+    def test_auto_panorama_enables(self):
+        _, _, _, ov, _ = parse(["--auto-panorama"])
+        assert ov["autoPanorama"] is True
+
+    def test_no_auto_panorama_disables(self):
+        _, _, _, ov, _ = parse(["--no-auto-panorama"])
+        assert ov["autoPanorama"] is False
+
+    def test_no_flag_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "autoPanorama" not in ov
+
+
+# ── Recursive ────────────────────────────────────────────────────────────────
+
+class TestRecursive:
+    def test_recursive_flag_sets_override(self):
+        _, _, _, ov, _ = parse(["--recursive"])
+        assert ov["recursive"] is True
+
+    def test_no_recursive_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "recursive" not in ov
+
+
+# ── Loop ─────────────────────────────────────────────────────────────────────
+
+class TestLoop:
+    def test_loop_enables(self):
+        _, _, _, ov, _ = parse(["--loop"])
+        assert ov["loop"] is True
+
+    def test_no_loop_disables(self):
+        _, _, _, ov, _ = parse(["--no-loop"])
+        assert ov["loop"] is False
+
+    def test_no_flag_not_in_overrides(self):
+        _, _, _, ov, _ = parse([])
+        assert "loop" not in ov
+
+
+# ── Combined / integration ────────────────────────────────────────────────────
+
+class TestCombined:
+    def test_kiosk_with_all_show_options(self):
+        kiosk, start, fs, ov, _ = parse([
+            "--kiosk", "--recursive", "--fullscreen",
+            "--autoplay", "3", "--loop",
+            "--transition", "zoom",
+            "--transition-dur", "400",
+            "--sort", "date",
+            "--scale", "fill",
+            "--auto-panorama",
+            "/photos",
+        ])
+        assert kiosk == "/photos"
+        assert start is None
+        assert fs is True
+        assert ov["autoplay"] is True
+        assert ov["interval"] == 3000
+        assert ov["transition"] == "zoom"
+        assert ov["transitionDuration"] == 400
+        assert ov["sort"] == "date"
+        assert ov["imageFill"] is True
+        assert ov["autoPanorama"] is True
+        assert ov["recursive"] is True
+        assert ov["loop"] is True
+
+    def test_jump_start_with_show_options(self):
+        kiosk, start, fs, ov, _ = parse([
+            "--autoplay", "10", "--transition", "fade",
+            "--sort", "random", "--no-loop",
+            "/mnt/photos",
+        ])
+        assert kiosk is None
+        assert start == "/mnt/photos"
+        assert fs is False
+        assert ov["autoplay"] is True
+        assert ov["interval"] == 10000
+        assert ov["transition"] == "fade"
+        assert ov["sort"] == "random"
+        assert ov["loop"] is False


### PR DESCRIPTION
…ptions

Add --sort, --scale, --transition-dur, --auto-panorama/--no-auto-panorama flags. Fix --kiosk to be a boolean flag (folder always positional). Fix CLI overrides being written to wrong QSettings location (before app name was set). Add 44 tests covering all flags, boundary clamping, and invalid value rejection.